### PR TITLE
Use current sign in at

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can then add to your 'config/sidekiq.yml' file:
 ## Available tasks
 
 - [ ] **Delete inactive users**
-  - Cron task that checks for user accounts where `last_sign_in_at` is superior to environment variable `CLEANER_USER_INACTIVITY_LIMIT`. If true, deletes inactive user from the database.
+  - Cron task that checks for user accounts where `current_sign_in_at` is superior to environment variable `CLEANER_USER_INACTIVITY_LIMIT`. If true, deletes inactive user from the database.
 
 - [ ] **Delete old admin logs**
   - Cron task that checks for admin logs where `created_at` is anterior to the time you configured in the back office. If true, deletes old admin logs from the database.

--- a/app/jobs/decidim/cleaner/clean_inactive_users_job.rb
+++ b/app/jobs/decidim/cleaner/clean_inactive_users_job.rb
@@ -12,7 +12,7 @@ module Decidim
           send_warning(Decidim::User.where(organization:)
                                     .not_deleted
                                     .where.not(email: "")
-                                    .where("last_sign_in_at < ?", email_inactive_before_date(organization)))
+                                    .where("current_sign_in_at < ?", email_inactive_before_date(organization)))
           delete_user_and_send_email(Decidim::User.where(organization:)
                                                   .not_deleted
                                                   .where.not(email: "")
@@ -31,7 +31,7 @@ module Decidim
 
       def delete_user_and_send_email(users)
         users.find_each do |user|
-          if user.last_sign_in_at > user.warning_date
+          if user.current_sign_in_at > user.warning_date
             user.update!(warning_date: nil)
             Rails.logger.info "User with id #{user.id} has logged in again, warning date reset"
             next

--- a/spec/jobs/decidim/cleaner/clean_inactive_users_job_spec.rb
+++ b/spec/jobs/decidim/cleaner/clean_inactive_users_job_spec.rb
@@ -7,8 +7,8 @@ describe Decidim::Cleaner::CleanInactiveUsersJob do
 
   context "when the delay is specified" do
     let!(:organization) { create(:organization, delete_inactive_users: true, delete_inactive_users_email_after: 25, delete_inactive_users_after: 5) }
-    let!(:pending_user) { create(:user, organization:, last_sign_in_at: 27.days.ago) }
-    let!(:inactive_user) { create(:user, organization:, last_sign_in_at: 35.days.ago, warning_date: 10.days.ago) }
+    let!(:pending_user) { create(:user, organization:, current_sign_in_at: 27.days.ago) }
+    let!(:inactive_user) { create(:user, organization:, current_sign_in_at: 35.days.ago, warning_date: 10.days.ago) }
     let!(:user) { create(:user, organization:) }
 
     it "enqueues job in queue 'cleaner'" do
@@ -32,8 +32,8 @@ describe Decidim::Cleaner::CleanInactiveUsersJob do
     end
 
     context "when users have destroyed his/her account" do
-      let!(:pending_user) { create(:user, :deleted, organization:, last_sign_in_at: 27.days.ago) }
-      let!(:inactive_user) { create(:user, :deleted, organization:, last_sign_in_at: 35.days.ago, warning_date: 10.days.ago) }
+      let!(:pending_user) { create(:user, :deleted, organization:, current_sign_in_at: 27.days.ago) }
+      let!(:inactive_user) { create(:user, :deleted, organization:, current_sign_in_at: 35.days.ago, warning_date: 10.days.ago) }
 
       it "doesn't send email" do
         expect(Decidim::Cleaner::InactiveUsersMailer).not_to receive(:warning_inactive).with(pending_user).and_call_original
@@ -53,7 +53,7 @@ describe Decidim::Cleaner::CleanInactiveUsersJob do
     end
 
     context "when user reconnect after warning" do
-      let!(:inactive_user) { create(:user, organization:, last_sign_in_at: 7.days.ago, warning_date: 10.days.ago) }
+      let!(:inactive_user) { create(:user, organization:, current_sign_in_at: 7.days.ago, warning_date: 10.days.ago) }
 
       it "doesn't send email" do
         expect(Decidim::Cleaner::InactiveUsersMailer).not_to receive(:warning_deletion).with(inactive_user).and_call_original


### PR DESCRIPTION
#### Description

Warning date must be based on `current_sign_in_at` rather than `last_sign_in_at`: See documentation of [Module: Devise::Models::Trackable](https://www.rubydoc.info/github/plataformatec/devise/Devise/Models/Trackable)