### PR TITLE
Unscope users to encompass default scoping by privacy module

### DIFF
--- a/app/jobs/decidim/cleaner/clean_inactive_users_job.rb
+++ b/app/jobs/decidim/cleaner/clean_inactive_users_job.rb
@@ -9,11 +9,11 @@ module Decidim
         Decidim::Organization.find_each do |organization|
           next unless organization.delete_inactive_users?
 
-          send_warning(Decidim::User.where(organization:)
+          send_warning(Decidim::User.unscoped.where(organization:)
                                     .not_deleted
                                     .where.not(email: "")
                                     .where("current_sign_in_at < ?", email_inactive_before_date(organization)))
-          delete_user_and_send_email(Decidim::User.where(organization:)
+          delete_user_and_send_email(Decidim::User.unscoped.where(organization:)
                                                   .not_deleted
                                                   .where.not(email: "")
                                                   .where("warning_date < ?", delete_inactive_before_date(organization)))


### PR DESCRIPTION
Recently, we've identified conflicts and incompatibilities within one of our modules, [decidim-module-privacy](https://github.com/mainio/decidim-module-privacy), when used alongside your module. After investigation, we've pinpointed the underlying issue, which I will outline below:

As part of the solution implemented for our module, we introduced a default_scope for the `Decidim::User` model. The default_scope is one of Rails' predefined methods that can be legitimately applied to any model. In our context, the default scope excludes private users from exposure, and setting it to default implies that any new user will be considered private until their account is manually set to public. 

To mitigate this issue safely, we propose adding the `unscoped` method to the User model prior to invoking any cued jobs. This approach ensures that normal cases remain unaffected while accommodating scenarios like ours.